### PR TITLE
Association labels

### DIFF
--- a/dealflow.go
+++ b/dealflow.go
@@ -10,7 +10,7 @@ import (
 )
 
 type IHubspotDealFlowAPI interface {
-	AssociateDealFlowCard(dealId, assocId string, assocType CardAssociation) error
+	AssociateDealFlowCard(dealId, assocId, objectType, assocType string) error
 	CreateDealFlowCard(
 		cardName string,
 		contactID string,
@@ -87,7 +87,7 @@ func NewHubspotDealFlowAPI(apiKey string) HubspotDealFlowAPI {
 
 // AssociateDealFlowCard associates a deal flow card with a company or contact using the internal HubSpot dealId and companyId/contactId
 // Choose whether to associate a company or contact by setting assocType to "contact" or "company"
-func (api HubspotDealFlowAPI) AssociateDealFlowCard(dealId, assocId string, objectType string, assocType string) error {
+func (api HubspotDealFlowAPI) AssociateDealFlowCard(dealId, assocId, objectType, assocType string) error {
 	url := fmt.Sprintf("https://api.hubapi.com/crm/v3/associations/deal/%s/batch/create?hapikey=%s",
 		objectType,
 		api.APIKey,

--- a/dealflow.go
+++ b/dealflow.go
@@ -103,11 +103,19 @@ func (api HubspotDealFlowAPI) AssociateDealFlowCard(dealId, assocId, objectType,
 		},
 	}
 
+	fmt.Printf("Association URL :%s\n", url)
+
+	bodyJSON, _ := json.Marshal(associationRequest)
+
+	fmt.Printf("Association Body:%s\n", bodyJSON)
+
 	payloadBuf := new(bytes.Buffer)
 	err := json.NewEncoder(payloadBuf).Encode(associationRequest)
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf("Payload Buffer  :%s\n", payloadBuf)
 
 	req, err := http.NewRequest("POST", url, payloadBuf)
 	if err != nil {

--- a/dealflow.go
+++ b/dealflow.go
@@ -122,6 +122,8 @@ func (api HubspotDealFlowAPI) AssociateDealFlowCard(dealId, assocId, objectType,
 		return err
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	_, err = api.httpClient.Do(req)
 	if err != nil {
 		return err

--- a/dealflow.go
+++ b/dealflow.go
@@ -14,6 +14,7 @@ type IHubspotDealFlowAPI interface {
 	CreateDealFlowCard(
 		cardName string,
 		contactID string,
+		contactAssocType string,
 		companyID string,
 		stageName string,
 		pipeline string,
@@ -103,19 +104,11 @@ func (api HubspotDealFlowAPI) AssociateDealFlowCard(dealId, assocId, objectType,
 		},
 	}
 
-	fmt.Printf("Association URL :%s\n", url)
-
-	bodyJSON, _ := json.Marshal(associationRequest)
-
-	fmt.Printf("Association Body:%s\n", bodyJSON)
-
 	payloadBuf := new(bytes.Buffer)
 	err := json.NewEncoder(payloadBuf).Encode(associationRequest)
 	if err != nil {
 		return err
 	}
-
-	fmt.Printf("Payload Buffer  :%s\n", payloadBuf)
 
 	req, err := http.NewRequest("POST", url, payloadBuf)
 	if err != nil {
@@ -137,6 +130,7 @@ func (api HubspotDealFlowAPI) AssociateDealFlowCard(dealId, assocId, objectType,
 func (api HubspotDealFlowAPI) CreateDealFlowCard(
 	cardName string,
 	contactID string,
+	contactAssocType string,
 	companyID string,
 	stageName string,
 	pipeline string,
@@ -200,7 +194,7 @@ func (api HubspotDealFlowAPI) CreateDealFlowCard(
 	}
 
 	// Associate the deal with a contact based on the application id
-	err = api.AssociateDealFlowCard(hubspotResp.Id, contactID, "contact", "deal_to_contact")
+	err = api.AssociateDealFlowCard(hubspotResp.Id, contactID, "contact", contactAssocType)
 	if err != nil {
 		return nil, err
 	}

--- a/dealflow.go
+++ b/dealflow.go
@@ -37,8 +37,8 @@ type dealCreationRequest struct {
 	Properties map[string]string `json:"properties"`
 }
 
-// dealCreationResponseProperties is a representation of the deal creation response from HubSpot
-type dealCreationResponseProperties struct {
+// DealCreationResponseProperties is a representation of the deal creation response from HubSpot
+type DealCreationResponseProperties struct {
 	Amount             string `json:"amount"`
 	CloseDate          string `json:"closedate"`
 	CreateDate         string `json:"createdate"`
@@ -52,7 +52,7 @@ type dealCreationResponseProperties struct {
 // DealCreationResponse is a representation of the deal creation response from HubSpot
 type DealCreationResponse struct {
 	Id         string                         `json:"id"`
-	Properties dealCreationResponseProperties `json:"properties"`
+	Properties DealCreationResponseProperties `json:"properties"`
 	CreatedAt  string                         `json:"createdAt"`
 	UpdatedAt  string                         `json:"updatedAt"`
 	Archived   bool                           `json:"archived"`

--- a/dealflow.go
+++ b/dealflow.go
@@ -64,17 +64,17 @@ type dealUpdateRequest struct {
 type CardAssociation int64
 
 type DealAssociationFromTo struct {
-	Id string
+	Id string `json:"id"`
 }
 
 type DealAssociation struct {
-	From DealAssociationFromTo
-	To   DealAssociationFromTo
-	Type string
+	From DealAssociationFromTo `json:"from"`
+	To   DealAssociationFromTo `json:"to"`
+	Type string                `json:"type"`
 }
 
 type DealAssociationBatchRequest struct {
-	Inputs []DealAssociation
+	Inputs []DealAssociation `json:"inputs"`
 }
 
 // NewHubspotDealFlowAPI creates new HubspotDealFlowAPI with form ID and API key

--- a/dealflow.go
+++ b/dealflow.go
@@ -109,7 +109,7 @@ func (api HubspotDealFlowAPI) AssociateDealFlowCard(dealId, assocId, objectType,
 		return err
 	}
 
-	req, err := http.NewRequest("PUT", url, payloadBuf)
+	req, err := http.NewRequest("POST", url, payloadBuf)
 	if err != nil {
 		return err
 	}

--- a/dealflow_mock.go
+++ b/dealflow_mock.go
@@ -20,7 +20,7 @@ var _ IHubspotDealFlowAPI = &IHubspotDealFlowAPIMock{}
 // 			AssociateDealFlowCardFunc: func(dealId string, assocId string, objectType string, assocType string) error {
 // 				panic("mock out the AssociateDealFlowCard method")
 // 			},
-// 			CreateDealFlowCardFunc: func(cardName string, contactID string, companyID string, stageName string, pipeline string, ownerId string, otherProperties map[string]string) (*DealCreationResponse, error) {
+// 			CreateDealFlowCardFunc: func(cardName string, contactID string, contactAssocType string, companyID string, stageName string, pipeline string, ownerId string, otherProperties map[string]string) (*DealCreationResponse, error) {
 // 				panic("mock out the CreateDealFlowCard method")
 // 			},
 // 			UpdateDealFlowCardFunc: func(dealId string, properties map[string]string) error {
@@ -37,7 +37,7 @@ type IHubspotDealFlowAPIMock struct {
 	AssociateDealFlowCardFunc func(dealId string, assocId string, objectType string, assocType string) error
 
 	// CreateDealFlowCardFunc mocks the CreateDealFlowCard method.
-	CreateDealFlowCardFunc func(cardName string, contactID string, companyID string, stageName string, pipeline string, ownerId string, otherProperties map[string]string) (*DealCreationResponse, error)
+	CreateDealFlowCardFunc func(cardName string, contactID string, contactAssocType string, companyID string, stageName string, pipeline string, ownerId string, otherProperties map[string]string) (*DealCreationResponse, error)
 
 	// UpdateDealFlowCardFunc mocks the UpdateDealFlowCard method.
 	UpdateDealFlowCardFunc func(dealId string, properties map[string]string) error
@@ -61,6 +61,8 @@ type IHubspotDealFlowAPIMock struct {
 			CardName string
 			// ContactID is the contactID argument value.
 			ContactID string
+			// ContactAssocType is the contactAssocType argument value.
+			ContactAssocType string
 			// CompanyID is the companyID argument value.
 			CompanyID string
 			// StageName is the stageName argument value.
@@ -129,53 +131,57 @@ func (mock *IHubspotDealFlowAPIMock) AssociateDealFlowCardCalls() []struct {
 }
 
 // CreateDealFlowCard calls CreateDealFlowCardFunc.
-func (mock *IHubspotDealFlowAPIMock) CreateDealFlowCard(cardName string, contactID string, companyID string, stageName string, pipeline string, ownerId string, otherProperties map[string]string) (*DealCreationResponse, error) {
+func (mock *IHubspotDealFlowAPIMock) CreateDealFlowCard(cardName string, contactID string, contactAssocType string, companyID string, stageName string, pipeline string, ownerId string, otherProperties map[string]string) (*DealCreationResponse, error) {
 	if mock.CreateDealFlowCardFunc == nil {
 		panic("IHubspotDealFlowAPIMock.CreateDealFlowCardFunc: method is nil but IHubspotDealFlowAPI.CreateDealFlowCard was just called")
 	}
 	callInfo := struct {
-		CardName        string
-		ContactID       string
-		CompanyID       string
-		StageName       string
-		Pipeline        string
-		OwnerId         string
-		OtherProperties map[string]string
+		CardName         string
+		ContactID        string
+		ContactAssocType string
+		CompanyID        string
+		StageName        string
+		Pipeline         string
+		OwnerId          string
+		OtherProperties  map[string]string
 	}{
-		CardName:        cardName,
-		ContactID:       contactID,
-		CompanyID:       companyID,
-		StageName:       stageName,
-		Pipeline:        pipeline,
-		OwnerId:         ownerId,
-		OtherProperties: otherProperties,
+		CardName:         cardName,
+		ContactID:        contactID,
+		ContactAssocType: contactAssocType,
+		CompanyID:        companyID,
+		StageName:        stageName,
+		Pipeline:         pipeline,
+		OwnerId:          ownerId,
+		OtherProperties:  otherProperties,
 	}
 	mock.lockCreateDealFlowCard.Lock()
 	mock.calls.CreateDealFlowCard = append(mock.calls.CreateDealFlowCard, callInfo)
 	mock.lockCreateDealFlowCard.Unlock()
-	return mock.CreateDealFlowCardFunc(cardName, contactID, companyID, stageName, pipeline, ownerId, otherProperties)
+	return mock.CreateDealFlowCardFunc(cardName, contactID, contactAssocType, companyID, stageName, pipeline, ownerId, otherProperties)
 }
 
 // CreateDealFlowCardCalls gets all the calls that were made to CreateDealFlowCard.
 // Check the length with:
 //     len(mockedIHubspotDealFlowAPI.CreateDealFlowCardCalls())
 func (mock *IHubspotDealFlowAPIMock) CreateDealFlowCardCalls() []struct {
-	CardName        string
-	ContactID       string
-	CompanyID       string
-	StageName       string
-	Pipeline        string
-	OwnerId         string
-	OtherProperties map[string]string
+	CardName         string
+	ContactID        string
+	ContactAssocType string
+	CompanyID        string
+	StageName        string
+	Pipeline         string
+	OwnerId          string
+	OtherProperties  map[string]string
 } {
 	var calls []struct {
-		CardName        string
-		ContactID       string
-		CompanyID       string
-		StageName       string
-		Pipeline        string
-		OwnerId         string
-		OtherProperties map[string]string
+		CardName         string
+		ContactID        string
+		ContactAssocType string
+		CompanyID        string
+		StageName        string
+		Pipeline         string
+		OwnerId          string
+		OtherProperties  map[string]string
 	}
 	mock.lockCreateDealFlowCard.RLock()
 	calls = mock.calls.CreateDealFlowCard

--- a/dealflow_mock.go
+++ b/dealflow_mock.go
@@ -17,7 +17,7 @@ var _ IHubspotDealFlowAPI = &IHubspotDealFlowAPIMock{}
 //
 // 		// make and configure a mocked IHubspotDealFlowAPI
 // 		mockedIHubspotDealFlowAPI := &IHubspotDealFlowAPIMock{
-// 			AssociateDealFlowCardFunc: func(dealId string, assocId string, assocType CardAssociation) error {
+// 			AssociateDealFlowCardFunc: func(dealId string, assocId string, objectType string, assocType string) error {
 // 				panic("mock out the AssociateDealFlowCard method")
 // 			},
 // 			CreateDealFlowCardFunc: func(cardName string, contactID string, companyID string, stageName string, pipeline string, ownerId string, otherProperties map[string]string) (*DealCreationResponse, error) {
@@ -34,7 +34,7 @@ var _ IHubspotDealFlowAPI = &IHubspotDealFlowAPIMock{}
 // 	}
 type IHubspotDealFlowAPIMock struct {
 	// AssociateDealFlowCardFunc mocks the AssociateDealFlowCard method.
-	AssociateDealFlowCardFunc func(dealId string, assocId string, assocType CardAssociation) error
+	AssociateDealFlowCardFunc func(dealId string, assocId string, objectType string, assocType string) error
 
 	// CreateDealFlowCardFunc mocks the CreateDealFlowCard method.
 	CreateDealFlowCardFunc func(cardName string, contactID string, companyID string, stageName string, pipeline string, ownerId string, otherProperties map[string]string) (*DealCreationResponse, error)
@@ -50,8 +50,10 @@ type IHubspotDealFlowAPIMock struct {
 			DealId string
 			// AssocId is the assocId argument value.
 			AssocId string
+			// ObjectType is the objectType argument value.
+			ObjectType string
 			// AssocType is the assocType argument value.
-			AssocType CardAssociation
+			AssocType string
 		}
 		// CreateDealFlowCard holds details about calls to the CreateDealFlowCard method.
 		CreateDealFlowCard []struct {
@@ -84,37 +86,41 @@ type IHubspotDealFlowAPIMock struct {
 }
 
 // AssociateDealFlowCard calls AssociateDealFlowCardFunc.
-func (mock *IHubspotDealFlowAPIMock) AssociateDealFlowCard(dealId string, assocId string, assocType CardAssociation) error {
+func (mock *IHubspotDealFlowAPIMock) AssociateDealFlowCard(dealId string, assocId string, objectType string, assocType string) error {
 	if mock.AssociateDealFlowCardFunc == nil {
 		panic("IHubspotDealFlowAPIMock.AssociateDealFlowCardFunc: method is nil but IHubspotDealFlowAPI.AssociateDealFlowCard was just called")
 	}
 	callInfo := struct {
-		DealId    string
-		AssocId   string
-		AssocType CardAssociation
+		DealId     string
+		AssocId    string
+		ObjectType string
+		AssocType  string
 	}{
-		DealId:    dealId,
-		AssocId:   assocId,
-		AssocType: assocType,
+		DealId:     dealId,
+		AssocId:    assocId,
+		ObjectType: objectType,
+		AssocType:  assocType,
 	}
 	mock.lockAssociateDealFlowCard.Lock()
 	mock.calls.AssociateDealFlowCard = append(mock.calls.AssociateDealFlowCard, callInfo)
 	mock.lockAssociateDealFlowCard.Unlock()
-	return mock.AssociateDealFlowCardFunc(dealId, assocId, assocType)
+	return mock.AssociateDealFlowCardFunc(dealId, assocId, objectType, assocType)
 }
 
 // AssociateDealFlowCardCalls gets all the calls that were made to AssociateDealFlowCard.
 // Check the length with:
 //     len(mockedIHubspotDealFlowAPI.AssociateDealFlowCardCalls())
 func (mock *IHubspotDealFlowAPIMock) AssociateDealFlowCardCalls() []struct {
-	DealId    string
-	AssocId   string
-	AssocType CardAssociation
+	DealId     string
+	AssocId    string
+	ObjectType string
+	AssocType  string
 } {
 	var calls []struct {
-		DealId    string
-		AssocId   string
-		AssocType CardAssociation
+		DealId     string
+		AssocId    string
+		ObjectType string
+		AssocType  string
 	}
 	mock.lockAssociateDealFlowCard.RLock()
 	calls = mock.calls.AssociateDealFlowCard

--- a/dealflow_test.go
+++ b/dealflow_test.go
@@ -24,7 +24,7 @@ func TestCreateDealFlowCard(t *testing.T) {
 
 	expected := DealCreationResponse{
 		"dealId",
-		dealCreationResponseProperties{
+		DealCreationResponseProperties{
 			"Amount",
 			"CloseDate",
 			"CreateDate",

--- a/dealflow_test.go
+++ b/dealflow_test.go
@@ -203,7 +203,7 @@ func TestCreateDealFlowCard(t *testing.T) {
 						{
 							From: DealAssociationFromTo{Id: "dealId"},
 							To:   DealAssociationFromTo{Id: "contactId"},
-							Type: "deal_to_contact",
+							Type: "contactAssocType",
 						},
 					},
 				}
@@ -245,6 +245,7 @@ func TestCreateDealFlowCard(t *testing.T) {
 	response, err := api.CreateDealFlowCard(
 		"cardName",
 		"contactId",
+		"contactAssocType",
 		"companyId",
 		"stageName",
 		"pipeline",

--- a/dealflow_test.go
+++ b/dealflow_test.go
@@ -154,8 +154,8 @@ func TestCreateDealFlowCard(t *testing.T) {
 				}
 			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/company/batch/create?hapikey=api_key" {
 				// Created an association between the deal and correct company
-				if req.Method != "PUT" {
-					t.Errorf("Deal association used %s, instead of PUT", req.Method)
+				if req.Method != "POST" {
+					t.Errorf("Deal association used %s, instead of POST", req.Method)
 				}
 
 				expectedRequest := DealAssociationBatchRequest{
@@ -194,8 +194,8 @@ func TestCreateDealFlowCard(t *testing.T) {
 				w.WriteHeader(200)
 			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/contact/batch/create?hapikey=api_key" {
 				// Created an association between the deal and correct company
-				if req.Method != "PUT" {
-					t.Errorf("Deal association used %s, instead of PUT", req.Method)
+				if req.Method != "POST" {
+					t.Errorf("Deal association used %s, instead of POST", req.Method)
 				}
 
 				expectedRequest := DealAssociationBatchRequest{
@@ -289,8 +289,8 @@ func TestAssociateDealFlowCard(t *testing.T) {
 
 			if url == "https://api.hubapi.com/crm/v3/associations/deal/company/batch/create?hapikey=api_key" {
 				// Created an association between the deal and correct company
-				if req.Method != "PUT" {
-					t.Errorf("Deal association used %s, instead of PUT", req.Method)
+				if req.Method != "POST" {
+					t.Errorf("Deal association used %s, instead of POST", req.Method)
 				}
 
 				expectedRequest := DealAssociationBatchRequest{
@@ -327,8 +327,8 @@ func TestAssociateDealFlowCard(t *testing.T) {
 				w.WriteHeader(200)
 			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/contact/batch/create?hapikey=api_key" {
 				// Created an association between the deal and correct company
-				if req.Method != "PUT" {
-					t.Errorf("Deal association used %s, instead of PUT", req.Method)
+				if req.Method != "POST" {
+					t.Errorf("Deal association used %s, instead of POST", req.Method)
 				}
 
 				expectedRequest := DealAssociationBatchRequest{

--- a/dealflow_test.go
+++ b/dealflow_test.go
@@ -3,6 +3,7 @@ package go_hubspot
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -11,11 +12,6 @@ import (
 	"strconv"
 	"testing"
 )
-
-// getDealFlowAPI Get default HubSpot DealFlow API client
-func getDealFlowAPI() HubspotDealFlowAPI {
-	return NewHubspotDealFlowAPI("key")
-}
 
 func getMockDealFlowAPI(mockClient *IHTTPClientMock) HubspotDealFlowAPI {
 	return HubspotDealFlowAPI{
@@ -27,7 +23,7 @@ func getMockDealFlowAPI(mockClient *IHTTPClientMock) HubspotDealFlowAPI {
 func TestCreateDealFlowCard(t *testing.T) {
 
 	expected := DealCreationResponse{
-		"dealid",
+		"dealId",
 		dealCreationResponseProperties{
 			"Amount",
 			"CloseDate",
@@ -156,18 +152,82 @@ func TestCreateDealFlowCard(t *testing.T) {
 				if err != nil {
 					t.Errorf("Error writing response in mock: %s", err.Error())
 				}
-			} else if url == "https://api.hubapi.com/crm/v3/objects/deals/dealid/associations/company/companyId/deal_to_company?hapikey=api_key" {
+			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/company/batch/create?hapikey=api_key" {
 				// Created an association between the deal and correct company
 				if req.Method != "PUT" {
 					t.Errorf("Deal association used %s, instead of PUT", req.Method)
 				}
 
+				expectedRequest := DealAssociationBatchRequest{
+					Inputs: []DealAssociation{
+						{
+							From: DealAssociationFromTo{Id: "dealId"},
+							To:   DealAssociationFromTo{Id: "companyId"},
+							Type: "deal_to_company",
+						},
+					},
+				}
+
+				body, err := ioutil.ReadAll(req.Body)
+				defer func(Body io.ReadCloser) {
+					err := Body.Close()
+					if err != nil {
+						t.Errorf("Error closing mock request body: %s", err.Error())
+					}
+				}(req.Body)
+
+				if err != nil {
+					t.Errorf("Error reading AssociateDealFlowCard request body: %s", err.Error())
+				}
+
+				var request DealAssociationBatchRequest
+				err = json.Unmarshal(body, &request)
+				if err != nil {
+					t.Errorf("Error unmarshalling AssociateDealFlowCard request: %s", err.Error())
+				}
+
+				if !cmp.Equal(expectedRequest, request) {
+					t.Errorf("Unexpected AssociateDealFlowCard request, expected:\n%s\ngot:\n%s", expectedRequest, request)
+				}
+
 				companyAssociation = true
 				w.WriteHeader(200)
-			} else if url == "https://api.hubapi.com/crm/v3/objects/deals/dealid/associations/contact/contactId/deal_to_contact?hapikey=api_key" {
+			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/contact/batch/create?hapikey=api_key" {
 				// Created an association between the deal and correct company
 				if req.Method != "PUT" {
 					t.Errorf("Deal association used %s, instead of PUT", req.Method)
+				}
+
+				expectedRequest := DealAssociationBatchRequest{
+					Inputs: []DealAssociation{
+						{
+							From: DealAssociationFromTo{Id: "dealId"},
+							To:   DealAssociationFromTo{Id: "contactId"},
+							Type: "deal_to_contact",
+						},
+					},
+				}
+
+				body, err := ioutil.ReadAll(req.Body)
+				defer func(Body io.ReadCloser) {
+					err := Body.Close()
+					if err != nil {
+						t.Errorf("Error closing mock request body: %s", err.Error())
+					}
+				}(req.Body)
+
+				if err != nil {
+					t.Errorf("Error reading AssociateDealFlowCard request body: %s", err.Error())
+				}
+
+				var request DealAssociationBatchRequest
+				err = json.Unmarshal(body, &request)
+				if err != nil {
+					t.Errorf("Error unmarshalling AssociateDealFlowCard request: %s", err.Error())
+				}
+
+				if !cmp.Equal(expectedRequest, request) {
+					t.Errorf("Unexpected AssociateDealFlowCard request, expected:\n%s\ngot:\n%s", expectedRequest, request)
 				}
 
 				contactAssociation = true
@@ -227,19 +287,81 @@ func TestAssociateDealFlowCard(t *testing.T) {
 			url := fmt.Sprintf("%s", req.URL)
 			w := httptest.NewRecorder()
 
-			if url == "https://api.hubapi.com/crm/v3/objects/deals/dealid/associations/company/companyid/deal_to_company?hapikey=api_key" {
+			if url == "https://api.hubapi.com/crm/v3/associations/deal/company/batch/create?hapikey=api_key" {
 				// Created an association between the deal and correct company
 				if req.Method != "PUT" {
 					t.Errorf("Deal association used %s, instead of PUT", req.Method)
 				}
 
+				expectedRequest := DealAssociationBatchRequest{
+					Inputs: []DealAssociation{
+						{
+							From: DealAssociationFromTo{Id: "dealId"},
+							To:   DealAssociationFromTo{Id: "companyId"},
+							Type: "company_type",
+						},
+					},
+				}
+
+				body, err := ioutil.ReadAll(req.Body)
+				defer func(Body io.ReadCloser) {
+					err := Body.Close()
+					if err != nil {
+						t.Errorf("Error closing mock request body: %s", err.Error())
+					}
+				}(req.Body)
+
+				if err != nil {
+					t.Errorf("Error reading AssociateDealFlowCard request body: %s", err.Error())
+				}
+
+				var request DealAssociationBatchRequest
+				err = json.Unmarshal(body, &request)
+				if err != nil {
+					t.Errorf("Error unmarshalling AssociateDealFlowCard request: %s", err.Error())
+				}
+
+				if !cmp.Equal(expectedRequest, request) {
+					t.Errorf("Unexpected AssociateDealFlowCard request, expected:\n%s\ngot:\n%s", expectedRequest, request)
+				}
 				w.WriteHeader(200)
-			} else if url == "https://api.hubapi.com/crm/v3/objects/deals/dealid/associations/contact/contactid/deal_to_contact?hapikey=api_key" {
+			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/contact/batch/create?hapikey=api_key" {
 				// Created an association between the deal and correct company
 				if req.Method != "PUT" {
 					t.Errorf("Deal association used %s, instead of PUT", req.Method)
 				}
 
+				expectedRequest := DealAssociationBatchRequest{
+					Inputs: []DealAssociation{
+						{
+							From: DealAssociationFromTo{Id: "dealId"},
+							To:   DealAssociationFromTo{Id: "contactId"},
+							Type: "contact_type",
+						},
+					},
+				}
+
+				body, err := ioutil.ReadAll(req.Body)
+				defer func(Body io.ReadCloser) {
+					err := Body.Close()
+					if err != nil {
+						t.Errorf("Error closing mock request body: %s", err.Error())
+					}
+				}(req.Body)
+
+				if err != nil {
+					t.Errorf("Error reading AssociateDealFlowCard request body: %s", err.Error())
+				}
+
+				var request DealAssociationBatchRequest
+				err = json.Unmarshal(body, &request)
+				if err != nil {
+					t.Errorf("Error unmarshalling AssociateDealFlowCard request: %s", err.Error())
+				}
+
+				if !cmp.Equal(expectedRequest, request) {
+					t.Errorf("Unexpected AssociateDealFlowCard request, expected:\n%s\ngot:\n%s", expectedRequest, request)
+				}
 				w.WriteHeader(200)
 			} else {
 				t.Errorf("Unexpected url %s", url)
@@ -251,13 +373,13 @@ func TestAssociateDealFlowCard(t *testing.T) {
 
 	api := getMockDealFlowAPI(&mockHubspotHTTPClient)
 
-	err := api.AssociateDealFlowCard("dealid", "companyid", Company)
+	err := api.AssociateDealFlowCard("dealId", "companyId", "company", "company_type")
 
 	if err != nil {
 		t.Errorf("Error on AssociateDealFlowCard: %s", err.Error())
 	}
 
-	err = api.AssociateDealFlowCard("dealid", "contactid", Contact)
+	err = api.AssociateDealFlowCard("dealId", "contactId", "contact", "contact_type")
 
 	if err != nil {
 		t.Errorf("Error on AssociateDealFlowCard: %s", err.Error())
@@ -276,7 +398,7 @@ func TestUpdateDealFlowCard(t *testing.T) {
 			url := fmt.Sprintf("%s", req.URL)
 
 			w := httptest.NewRecorder()
-			if url == "https://api.hubapi.com/crm/v3/objects/deals/dealid?hapikey=api_key" {
+			if url == "https://api.hubapi.com/crm/v3/objects/deals/dealId?hapikey=api_key" {
 				// This is a deal flow creation call
 				// Test the body
 
@@ -331,7 +453,7 @@ func TestUpdateDealFlowCard(t *testing.T) {
 	api := getMockDealFlowAPI(&mockHubspotHTTPClient)
 
 	err := api.UpdateDealFlowCard(
-		"dealid",
+		"dealId",
 		map[string]string{
 			"dealname":                  "dealName",
 			"dealstage":                 "stageName",


### PR DESCRIPTION
Update `AssociateDealFlowCard` to allow associations with arbitrary types (labels within HubSpot UI, types in the API) to be made between arbitrary custom object types.

Update `CreateDealFlowCard` so you can specify the association type between the deal and the contact which is created by HubSpot.

Addresses: https://trello.com/c/6tgzSovn