### PR TITLE
hubspot is deprecating the use of hapikey

### DIFF
--- a/crm.go
+++ b/crm.go
@@ -69,13 +69,13 @@ func NewHubspotCRMAPI(apiKey string) HubspotCRMAPI {
 // UpdateCompany updates company details in HubSpot CRM
 func (api HubspotCRMAPI) UpdateCompany(companyID string, jsonPayload *bytes.Buffer) error {
 	url := fmt.Sprintf(
-		"https://api.hubapi.com/crm/v3/objects/companies/%s?hapikey=%s",
+		"https://api.hubapi.com/crm/v3/objects/companies/%s",
 		companyID,
-		api.APIKey,
 	)
 
 	req, _ := http.NewRequest("PATCH", url, jsonPayload)
 
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", api.APIKey))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := api.httpClient.Do(req)
@@ -108,12 +108,13 @@ func (api HubspotCRMAPI) UpdateCompany(companyID string, jsonPayload *bytes.Buff
 // If no company is found "" is returned, no error is thrown
 func (api HubspotCRMAPI) GetCompanyForContact(contactID string) (string, error) {
 	url := fmt.Sprintf(
-		"https://api.hubapi.com/crm/v3/objects/contacts/%s/associations/company?hapikey=%s",
+		"https://api.hubapi.com/crm/v3/objects/contacts/%s/associations/company",
 		contactID,
-		api.APIKey,
 	)
 
 	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", api.APIKey))
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := api.httpClient.Do(req)
 	if err != nil {
@@ -148,12 +149,13 @@ func (api HubspotCRMAPI) GetCompanyForContact(contactID string) (string, error) 
 // Returns "" with nil error if no company exists
 func (api HubspotCRMAPI) GetDealForCompany(companyID string) (string, error) {
 	url := fmt.Sprintf(
-		"https://api.hubapi.com/crm/v3/objects/companies/%s/associations/deal?limit=500&hapikey=%s",
+		"https://api.hubapi.com/crm/v3/objects/companies/%s/associations/deal?limit=500",
 		companyID,
-		api.APIKey,
 	)
 
 	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", api.APIKey))
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := api.httpClient.Do(req)
 	if err != nil {
@@ -198,8 +200,7 @@ func (api HubspotCRMAPI) SearchCompanies(filterMap map[string]string, properties
 
 // SearchHubSpot searches for an object type with the provided filters and returns properties for the results found
 func (api HubspotCRMAPI) SearchHubSpot(objectType string, filterMap map[string]string, properties []string) ([]HubSpotSearchResult, error) {
-	censoredUrl := fmt.Sprintf("https://api.hubapi.com/crm/v3/objects/%s/search?hapikey=%s", objectType, "<censored>")
-	url := fmt.Sprintf("https://api.hubapi.com/crm/v3/objects/%s/search?hapikey=%s", objectType, api.APIKey)
+	url := fmt.Sprintf("https://api.hubapi.com/crm/v3/objects/%s/search", objectType)
 
 	var filters = make([]filter, len(filterMap))
 	filterIndex := 0
@@ -220,7 +221,7 @@ func (api HubspotCRMAPI) SearchHubSpot(objectType string, filterMap map[string]s
 		Properties: properties,
 	}
 
-	log.Infof("Making query to contact search endpoint (%s) with: %#v", censoredUrl, searchQuery)
+	log.Infof("Making query to contact search endpoint (%s) with: %#v", url, searchQuery)
 
 	payloadBuf := new(bytes.Buffer)
 	err := json.NewEncoder(payloadBuf).Encode(searchQuery)
@@ -229,6 +230,7 @@ func (api HubspotCRMAPI) SearchHubSpot(objectType string, filterMap map[string]s
 	}
 
 	req, err := http.NewRequest("POST", url, payloadBuf)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", api.APIKey))
 	req.Header.Set("Content-Type", "application/json")
 
 	log.Infof("Query Payload: %s", payloadBuf.String())

--- a/crm_test.go
+++ b/crm_test.go
@@ -105,7 +105,7 @@ func generateMock(t *testing.T, response []byte) IHTTPClientMock {
 			}
 
 			w := httptest.NewRecorder()
-			expectedUrl := "https://api.hubapi.com/crm/v3/objects/objecttype/search?hapikey=api_key"
+			expectedUrl := "https://api.hubapi.com/crm/v3/objects/objecttype/search"
 			if url == expectedUrl {
 				if req.Method != "POST" {
 					t.Errorf("A request was made that should have been POST but was %s", req.Method)
@@ -187,7 +187,7 @@ func createCompanyForContactMock(t *testing.T, numberOfResults int) IHTTPClientM
 			url := fmt.Sprintf("%s", req.URL)
 
 			w := httptest.NewRecorder()
-			expectedUrl := "https://api.hubapi.com/crm/v3/objects/contacts/contactid/associations/company?hapikey=api_key"
+			expectedUrl := "https://api.hubapi.com/crm/v3/objects/contacts/contactid/associations/company"
 			if url == expectedUrl {
 
 				if req.Method != "GET" {
@@ -283,7 +283,7 @@ func createDealForCompanyMock(t *testing.T, numberOfResults int) IHTTPClientMock
 			url := fmt.Sprintf("%s", req.URL)
 
 			w := httptest.NewRecorder()
-			expectedUrl := "https://api.hubapi.com/crm/v3/objects/companies/companyid/associations/deal?limit=500&hapikey=api_key"
+			expectedUrl := "https://api.hubapi.com/crm/v3/objects/companies/companyid/associations/deal?limit=500"
 			if url == expectedUrl {
 
 				if req.Method != "GET" {

--- a/dealflow.go
+++ b/dealflow.go
@@ -89,9 +89,8 @@ func NewHubspotDealFlowAPI(apiKey string) HubspotDealFlowAPI {
 // AssociateDealFlowCard associates a deal flow card with a company or contact using the internal HubSpot dealId and companyId/contactId
 // Choose whether to associate a company or contact by setting assocType to "contact" or "company"
 func (api HubspotDealFlowAPI) AssociateDealFlowCard(dealId, assocId, objectType, assocType string) error {
-	url := fmt.Sprintf("https://api.hubapi.com/crm/v3/associations/deal/%s/batch/create?hapikey=%s",
+	url := fmt.Sprintf("https://api.hubapi.com/crm/v3/associations/deal/%s/batch/create",
 		objectType,
-		api.APIKey,
 	)
 
 	associationRequest := DealAssociationBatchRequest{
@@ -115,6 +114,7 @@ func (api HubspotDealFlowAPI) AssociateDealFlowCard(dealId, assocId, objectType,
 		return err
 	}
 
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", api.APIKey))
 	req.Header.Set("Content-Type", "application/json")
 
 	_, err = api.httpClient.Do(req)
@@ -140,7 +140,7 @@ func (api HubspotDealFlowAPI) CreateDealFlowCard(
 
 	log.Infof("Creating a deal flow card")
 
-	url := fmt.Sprintf("https://api.hubapi.com/crm/v3/objects/deals?hapikey=%s", api.APIKey)
+	url := "https://api.hubapi.com/crm/v3/objects/deals"
 
 	creationRequest := dealCreationRequest{
 		map[string]string{
@@ -162,6 +162,7 @@ func (api HubspotDealFlowAPI) CreateDealFlowCard(
 	}
 
 	req, err := http.NewRequest("POST", url, payloadBuf)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", api.APIKey))
 	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return nil, err
@@ -211,7 +212,7 @@ func (api HubspotDealFlowAPI) UpdateDealFlowCard(
 
 	log.Infof("Updating a deal flow card")
 
-	url := fmt.Sprintf("https://api.hubapi.com/crm/v3/objects/deals/%s?hapikey=%s", dealId, api.APIKey)
+	url := fmt.Sprintf("https://api.hubapi.com/crm/v3/objects/deals/%s", dealId)
 
 	updateRequest := dealUpdateRequest{
 		properties,
@@ -224,6 +225,7 @@ func (api HubspotDealFlowAPI) UpdateDealFlowCard(
 	}
 
 	req, err := http.NewRequest("PATCH", url, payloadBuf)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", api.APIKey))
 	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return err

--- a/dealflow_test.go
+++ b/dealflow_test.go
@@ -49,7 +49,7 @@ func TestCreateDealFlowCard(t *testing.T) {
 			url := fmt.Sprintf("%s", req.URL)
 
 			w := httptest.NewRecorder()
-			if url == "https://api.hubapi.com/crm/v3/objects/deals?hapikey=api_key" {
+			if url == "https://api.hubapi.com/crm/v3/objects/deals" {
 				// This is a deal flow creation call
 				// Test the body
 
@@ -97,7 +97,7 @@ func TestCreateDealFlowCard(t *testing.T) {
 				if err != nil {
 					t.Errorf("Error writing response in mock: %s", err.Error())
 				}
-			} else if url == "https://api.hubapi.com/crm/v3/objects/contacts/search?hapikey=api_key" {
+			} else if url == "https://api.hubapi.com/crm/v3/objects/contacts/search" {
 				// Searching for contact
 				searchResponse := HubSpotSearchResponse{
 					1,
@@ -123,7 +123,7 @@ func TestCreateDealFlowCard(t *testing.T) {
 				if err != nil {
 					t.Errorf("Error writing response in mock: %s", err.Error())
 				}
-			} else if url == "https://api.hubapi.com/crm/v3/objects/contacts/contactid?associations=company&archived=false&hapikey=api_key" {
+			} else if url == "https://api.hubapi.com/crm/v3/objects/contacts/contactid?associations=company&archived=false" {
 				// Searching for company
 				searchResponse := HubSpotSearchResult{
 					"contactid",
@@ -152,7 +152,7 @@ func TestCreateDealFlowCard(t *testing.T) {
 				if err != nil {
 					t.Errorf("Error writing response in mock: %s", err.Error())
 				}
-			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/company/batch/create?hapikey=api_key" {
+			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/company/batch/create" {
 				// Created an association between the deal and correct company
 				if req.Method != "POST" {
 					t.Errorf("Deal association used %s, instead of POST", req.Method)
@@ -192,7 +192,7 @@ func TestCreateDealFlowCard(t *testing.T) {
 
 				companyAssociation = true
 				w.WriteHeader(200)
-			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/contact/batch/create?hapikey=api_key" {
+			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/contact/batch/create" {
 				// Created an association between the deal and correct company
 				if req.Method != "POST" {
 					t.Errorf("Deal association used %s, instead of POST", req.Method)
@@ -288,7 +288,7 @@ func TestAssociateDealFlowCard(t *testing.T) {
 			url := fmt.Sprintf("%s", req.URL)
 			w := httptest.NewRecorder()
 
-			if url == "https://api.hubapi.com/crm/v3/associations/deal/company/batch/create?hapikey=api_key" {
+			if url == "https://api.hubapi.com/crm/v3/associations/deal/company/batch/create" {
 				// Created an association between the deal and correct company
 				if req.Method != "POST" {
 					t.Errorf("Deal association used %s, instead of POST", req.Method)
@@ -326,7 +326,7 @@ func TestAssociateDealFlowCard(t *testing.T) {
 					t.Errorf("Unexpected AssociateDealFlowCard request, expected:\n%s\ngot:\n%s", expectedRequest, request)
 				}
 				w.WriteHeader(200)
-			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/contact/batch/create?hapikey=api_key" {
+			} else if url == "https://api.hubapi.com/crm/v3/associations/deal/contact/batch/create" {
 				// Created an association between the deal and correct company
 				if req.Method != "POST" {
 					t.Errorf("Deal association used %s, instead of POST", req.Method)
@@ -399,7 +399,7 @@ func TestUpdateDealFlowCard(t *testing.T) {
 			url := fmt.Sprintf("%s", req.URL)
 
 			w := httptest.NewRecorder()
-			if url == "https://api.hubapi.com/crm/v3/objects/deals/dealId?hapikey=api_key" {
+			if url == "https://api.hubapi.com/crm/v3/objects/deals/dealId" {
 				// This is a deal flow creation call
 				// Test the body
 
@@ -479,7 +479,7 @@ func TestUpdateDealFlowCard(t *testing.T) {
 //			url := fmt.Sprintf("%s", req.URL)
 //
 //			w := httptest.NewRecorder()
-//			if url == "https://api.hubapi.com/crm/v3/objects/deals/dealid?hapikey=api_key" {
+//			if url == "https://api.hubapi.com/crm/v3/objects/deals/dealid" {
 //				// This is a deal flow creation call
 //				// Test the body
 //

--- a/file.go
+++ b/file.go
@@ -11,13 +11,12 @@ import (
 )
 
 type IHubspotFileAPI interface {
-	GetPageURL() string
 	UploadFile(file []byte, folderPath, fileName string) (string, error)
 }
 
 // HubspotFileAPI is the structure to interact with Hubspot File API
 type HubspotFileAPI struct {
-	URLTemplate string
+	URL string
 	APIKey      string
 	PortalID    string
 	httpClient  IHTTPClient
@@ -31,19 +30,11 @@ type FileUploadResponse struct {
 // NewHubspotFileAPI creates new HubspotFileAPI and API key
 func NewHubspotFileAPI(apiKey string, portalId string) HubspotFileAPI {
 	return HubspotFileAPI{
-		URLTemplate: "https://api.hubapi.com/files/v3/files?hapikey=%s",
+		URL: "https://api.hubapi.com/files/v3/files",
 		APIKey:      apiKey,
 		PortalID:    portalId,
 		httpClient:  HTTPClient{},
 	}
-}
-
-// GetPageURL gets query URL for a page of results
-func (api HubspotFileAPI) GetPageURL() string {
-	return fmt.Sprintf(
-		api.URLTemplate,
-		api.APIKey,
-	)
 }
 
 type FileUploadOptions struct {
@@ -94,11 +85,12 @@ func (api HubspotFileAPI) UploadFile(file []byte, folderPath, fileName string) (
 		return "", err
 	}
 
-	req, err := http.NewRequest("POST", api.GetPageURL(), &data)
+	req, err := http.NewRequest("POST", api.URL, &data)
 	if err != nil {
 		return "", errors.New(fmt.Sprintf("Error while constructing a request: %s", err.Error()))
 	}
 
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", api.APIKey))
 	req.Header.Set("Content-Type", w.FormDataContentType())
 
 	resp, err := api.httpClient.Do(req)

--- a/file_mock.go
+++ b/file_mock.go
@@ -17,9 +17,6 @@ var _ IHubspotFileAPI = &IHubspotFileAPIMock{}
 //
 // 		// make and configure a mocked IHubspotFileAPI
 // 		mockedIHubspotFileAPI := &IHubspotFileAPIMock{
-// 			GetPageURLFunc: func() string {
-// 				panic("mock out the GetPageURL method")
-// 			},
 // 			UploadFileFunc: func(file []byte, folderPath string, fileName string) (string, error) {
 // 				panic("mock out the UploadFile method")
 // 			},
@@ -30,17 +27,11 @@ var _ IHubspotFileAPI = &IHubspotFileAPIMock{}
 //
 // 	}
 type IHubspotFileAPIMock struct {
-	// GetPageURLFunc mocks the GetPageURL method.
-	GetPageURLFunc func() string
-
 	// UploadFileFunc mocks the UploadFile method.
 	UploadFileFunc func(file []byte, folderPath string, fileName string) (string, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// GetPageURL holds details about calls to the GetPageURL method.
-		GetPageURL []struct {
-		}
 		// UploadFile holds details about calls to the UploadFile method.
 		UploadFile []struct {
 			// File is the file argument value.
@@ -51,34 +42,7 @@ type IHubspotFileAPIMock struct {
 			FileName string
 		}
 	}
-	lockGetPageURL sync.RWMutex
 	lockUploadFile sync.RWMutex
-}
-
-// GetPageURL calls GetPageURLFunc.
-func (mock *IHubspotFileAPIMock) GetPageURL() string {
-	if mock.GetPageURLFunc == nil {
-		panic("IHubspotFileAPIMock.GetPageURLFunc: method is nil but IHubspotFileAPI.GetPageURL was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockGetPageURL.Lock()
-	mock.calls.GetPageURL = append(mock.calls.GetPageURL, callInfo)
-	mock.lockGetPageURL.Unlock()
-	return mock.GetPageURLFunc()
-}
-
-// GetPageURLCalls gets all the calls that were made to GetPageURL.
-// Check the length with:
-//     len(mockedIHubspotFileAPI.GetPageURLCalls())
-func (mock *IHubspotFileAPIMock) GetPageURLCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockGetPageURL.RLock()
-	calls = mock.calls.GetPageURL
-	mock.lockGetPageURL.RUnlock()
-	return calls
 }
 
 // UploadFile calls UploadFileFunc.

--- a/file_test.go
+++ b/file_test.go
@@ -13,7 +13,7 @@ import (
 
 func getMockFileAPI(mockClient *IHTTPClientMock) HubspotFileAPI {
 	return HubspotFileAPI{
-		URLTemplate: "https://api.hubapi.com/files/v3/files?hapikey=%s",
+		URL: "https://api.hubapi.com/files/v3/files",
 		APIKey:      "apiKey",
 		PortalID:    "portalId",
 		httpClient:  mockClient,
@@ -32,7 +32,7 @@ func TestUploadFile(t *testing.T) {
 			url := fmt.Sprintf("%s", req.URL)
 
 			w := httptest.NewRecorder()
-			if url == "https://api.hubapi.com/files/v3/files?hapikey=apiKey" {
+			if url == "https://api.hubapi.com/files/v3/files" {
 
 				if req.Method != "POST" {
 					t.Errorf("Unexpected method: expected POST, got: %s", req.Method)

--- a/form.go
+++ b/form.go
@@ -49,7 +49,7 @@ type HubspotResponse struct {
 // NewHubspotFormAPI creates new HubspotFormAPI with form ID and API key
 func NewHubspotFormAPI(formID string, apiKey string) HubspotFormAPI {
 	return HubspotFormAPI{
-		URLTemplate: "https://api.hubapi.com/form-integrations/v1/submissions/forms/%s?hapikey=%s&limit=50&after=%s",
+		URLTemplate: "https://api.hubapi.com/form-integrations/v1/submissions/forms/%s?limit=50&after=%s",
 		FormID:      formID,
 		APIKey:      apiKey,
 		httpClient:  HTTPClient{},
@@ -106,7 +106,6 @@ func (api HubspotFormAPI) GetPageURL(after string) string {
 	return fmt.Sprintf(
 		api.URLTemplate,
 		api.FormID,
-		api.APIKey,
 		after,
 	)
 }
@@ -115,7 +114,11 @@ func (api HubspotFormAPI) GetPageURL(after string) string {
 func (api HubspotFormAPI) Query(after string) (*HubspotResponse, error) {
 	url := api.GetPageURL(after)
 
-	resp, err := api.httpClient.Get(url)
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", api.APIKey))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := api.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/form_test.go
+++ b/form_test.go
@@ -72,7 +72,7 @@ func TestGetSubmissionMap(t *testing.T) {
 }
 
 func TestGetPageURL(t *testing.T) {
-	expected := "https://api.hubapi.com/form-integrations/v1/submissions/forms/form?hapikey=key&limit=50&after=some-application-id"
+	expected := "https://api.hubapi.com/form-integrations/v1/submissions/forms/form?limit=50&after=some-application-id"
 	api := getFormAPI()
 	got := api.GetPageURL("some-application-id")
 	if expected != got {
@@ -158,7 +158,7 @@ func TestSearchForApplicationID(t *testing.T) {
 		DoFunc: func(req *http.Request) (resp *http.Response, err error) { return nil, nil },
 		GetFunc: func(url string) (resp *http.Response, err error) {
 			w := httptest.NewRecorder()
-			if url == "https://example.com/form_id?hapikey=api_key&limit=50&after=" {
+			if url == "https://example.com/form_id?limit=50&after=" {
 				w.WriteHeader(200)
 				w.Write([]byte(`
 				{
@@ -187,7 +187,7 @@ func TestSearchForApplicationID(t *testing.T) {
 					}
 				}
 				`))
-			} else if url == "https://example.com/form_id?hapikey=api_key&limit=50&after=first" {
+			} else if url == "https://example.com/form_id?limit=50&after=first" {
 				w.WriteHeader(200)
 				w.Write([]byte(`
 				{
@@ -216,7 +216,7 @@ func TestSearchForApplicationID(t *testing.T) {
 					}
 				}
 				`))
-			} else if url == "https://example.com/form_id?hapikey=api_key&limit=50&after=second" {
+			} else if url == "https://example.com/form_id?limit=50&after=second" {
 				w.WriteHeader(200)
 				w.Write([]byte(`
 				{
@@ -230,7 +230,7 @@ func TestSearchForApplicationID(t *testing.T) {
 	}
 
 	api := HubspotFormAPI{
-		URLTemplate: "https://example.com/%s?hapikey=%s&limit=50&after=%s",
+		URLTemplate: "https://example.com/%s?limit=50&after=%s",
 		FormID:      "form_id",
 		APIKey:      "api_key",
 		httpClient:  &mockHubspotHTTPClient,
@@ -242,7 +242,7 @@ func TestSearchForApplicationID(t *testing.T) {
 		t.Errorf("Expected to find form with application_id1 on page 1")
 	}
 
-	if len(mockHubspotHTTPClient.GetCalls()) != 1 {
+	if len(mockHubspotHTTPClient.DoCalls()) != 1 {
 		t.Errorf("Expected 1 call to HubSpot API")
 	}
 
@@ -252,7 +252,7 @@ func TestSearchForApplicationID(t *testing.T) {
 		t.Errorf("Expected to find form with application_id2 on page 2")
 	}
 
-	if len(mockHubspotHTTPClient.GetCalls()) != 3 {
+	if len(mockHubspotHTTPClient.DoCalls()) != 3 {
 		t.Errorf("Expected 2 call to HubSpot API")
 	}
 
@@ -262,7 +262,7 @@ func TestSearchForApplicationID(t *testing.T) {
 		t.Errorf("Expected to not find form with application_id=none")
 	}
 
-	if len(mockHubspotHTTPClient.GetCalls()) != 6 {
+	if len(mockHubspotHTTPClient.DoCalls()) != 6 {
 		t.Errorf("Expected 3 call to HubSpot API")
 	}
 

--- a/httpclient.go
+++ b/httpclient.go
@@ -5,16 +5,10 @@ import "net/http"
 // IHTTPClient HTTP client interface to be used with HubSpot API clients
 type IHTTPClient interface {
 	Do(req *http.Request) (resp *http.Response, err error)
-	Get(url string) (resp *http.Response, err error)
 }
 
 // HTTPClient HTTP client to be used with HubSpot API clients
 type HTTPClient struct{}
-
-// Get makes a GET request to a given URL
-func (c HTTPClient) Get(url string) (resp *http.Response, err error) {
-	return http.Get(url)
-}
 
 // Do performs a request to a url
 func (c HTTPClient) Do(req *http.Request) (resp *http.Response, err error) {

--- a/httpclient_mock_test.go
+++ b/httpclient_mock_test.go
@@ -21,9 +21,6 @@ var _ IHTTPClient = &IHTTPClientMock{}
 // 			DoFunc: func(req *http.Request) (*http.Response, error) {
 // 				panic("mock out the Do method")
 // 			},
-// 			GetFunc: func(url string) (*http.Response, error) {
-// 				panic("mock out the Get method")
-// 			},
 // 		}
 //
 // 		// use mockedIHTTPClient in code that requires IHTTPClient
@@ -34,9 +31,6 @@ type IHTTPClientMock struct {
 	// DoFunc mocks the Do method.
 	DoFunc func(req *http.Request) (*http.Response, error)
 
-	// GetFunc mocks the Get method.
-	GetFunc func(url string) (*http.Response, error)
-
 	// calls tracks calls to the methods.
 	calls struct {
 		// Do holds details about calls to the Do method.
@@ -44,14 +38,8 @@ type IHTTPClientMock struct {
 			// Req is the req argument value.
 			Req *http.Request
 		}
-		// Get holds details about calls to the Get method.
-		Get []struct {
-			// URL is the url argument value.
-			URL string
-		}
 	}
 	lockDo  sync.RWMutex
-	lockGet sync.RWMutex
 }
 
 // Do calls DoFunc.
@@ -82,36 +70,5 @@ func (mock *IHTTPClientMock) DoCalls() []struct {
 	mock.lockDo.RLock()
 	calls = mock.calls.Do
 	mock.lockDo.RUnlock()
-	return calls
-}
-
-// Get calls GetFunc.
-func (mock *IHTTPClientMock) Get(url string) (*http.Response, error) {
-	if mock.GetFunc == nil {
-		panic("IHTTPClientMock.GetFunc: method is nil but IHTTPClient.Get was just called")
-	}
-	callInfo := struct {
-		URL string
-	}{
-		URL: url,
-	}
-	mock.lockGet.Lock()
-	mock.calls.Get = append(mock.calls.Get, callInfo)
-	mock.lockGet.Unlock()
-	return mock.GetFunc(url)
-}
-
-// GetCalls gets all the calls that were made to Get.
-// Check the length with:
-//     len(mockedIHTTPClient.GetCalls())
-func (mock *IHTTPClientMock) GetCalls() []struct {
-	URL string
-} {
-	var calls []struct {
-		URL string
-	}
-	mock.lockGet.RLock()
-	calls = mock.calls.Get
-	mock.lockGet.RUnlock()
 	return calls
 }


### PR DESCRIPTION
see https://developers.hubspot.com/docs/api/migrate-an-api-key-integration-to-a-private-app